### PR TITLE
Unifying memento endpoint by adding a redirect

### DIFF
--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -437,7 +437,7 @@ def getCompleteURI(uri):
 def showMementoAtDatetime(urir, datetime):
     urir = getCompleteURI(urir)
     datetime = datetime.ljust(14, '0')
-    return show_uri(urir, datetime)
+    return redirect("/memento/{0}/{1}".format(datetime, urir), code=301)
 
 
 @app.errorhandler(Exception)


### PR DESCRIPTION
This implements #342 for testing the implications of a redirect from one memento endpoint to the other and potentially removing one later.