### PR TITLE
Fabricate header when only payload is available for #369

### DIFF
--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -525,8 +525,6 @@ def show_uri(path, datetime=None):
     class HashNotFoundError(Exception):
         pass
 
-    payloadCatSuccess = False
-    headerCatSuccess = False
     payload = ''
     header = ''
     try:
@@ -536,12 +534,8 @@ def show_uri(path, datetime=None):
         signal.signal(signal.SIGALRM, handler)
         signal.alarm(10)
 
-        # TODO: Check how payload is populated on failure for optimization
-        #  via removing the need for the payloadCatSuccessVariable
         payload = IPFS_API.cat(digests[-1])
-        payloadCatSuccess = True
         header = IPFS_API.cat(digests[-2])
-        headerCatSuccess = True
 
         signal.alarm(0)
 
@@ -556,7 +550,7 @@ def show_uri(path, datetime=None):
         print(traceback.format_exc())
         print(sys.exc_info()[0])
     except HashNotFoundError:
-        if not payloadCatSuccess:
+        if payload == '':
             print("Hashes not found")
             return '', 404
         else:  # payload found but not header, fabricate header
@@ -614,7 +608,7 @@ def show_uri(path, datetime=None):
 
     resp.headers['Memento-Datetime'] = ipwbConfig.datetimeToRFC1123(datetime)
 
-    if not headerCatSuccess:
+    if header == '':
         resp.headers['X-Headers-Generated-By'] = 'InterPlanetary Wayback'
 
     # Get TimeMap for Link response header


### PR DESCRIPTION
@ibnesayeed Check this. There are better ways to do it but this at least gets payloads working again if the header if absent from IPFS.