### PR TITLE
Consider version and daemon flag on base argparser. Closes #424

### DIFF
--- a/ipwb/__main__.py
+++ b/ipwb/__main__.py
@@ -137,8 +137,7 @@ def checkArgs(argsIn):
     cmdError_index = argCount == 2 and argsIn[1] == 'index'
     cmdError_noCommand = argCount == 1
     cmdError_invalidCommand = argCount > 1 \
-        and argsIn[1] not in cmdList \
-        and argsIn[1] not in baseParserFlagList
+        and argsIn[1] not in cmdList + baseParserFlagList
 
     if cmdError_noCommand or cmdError_invalidCommand:
         parser.print_help()

--- a/ipwb/__main__.py
+++ b/ipwb/__main__.py
@@ -131,11 +131,14 @@ def checkArgs(argsIn):
 
     argCount = len(argsIn)
     cmdList = ['index', 'replay']
+    baseParserFlagList = ['-d', '--daemon', '-v', '--version']
 
     # Various invocation error, used to show appropriate help
     cmdError_index = argCount == 2 and argsIn[1] == 'index'
     cmdError_noCommand = argCount == 1
-    cmdError_invalidCommand = argCount > 1 and argsIn[1] not in cmdList
+    cmdError_invalidCommand = argCount > 1 \
+                              and argsIn[1] not in cmdList \
+                              and argsIn[1] not in baseParserFlagList
 
     if cmdError_noCommand or cmdError_invalidCommand:
         parser.print_help()

--- a/ipwb/__main__.py
+++ b/ipwb/__main__.py
@@ -137,8 +137,8 @@ def checkArgs(argsIn):
     cmdError_index = argCount == 2 and argsIn[1] == 'index'
     cmdError_noCommand = argCount == 1
     cmdError_invalidCommand = argCount > 1 \
-                              and argsIn[1] not in cmdList \
-                              and argsIn[1] not in baseParserFlagList
+        and argsIn[1] not in cmdList \
+        and argsIn[1] not in baseParserFlagList
 
     if cmdError_noCommand or cmdError_invalidCommand:
         parser.print_help()


### PR DESCRIPTION
The redundancy and hard-coding is not ideal, but this makes the version (and daemon) flags accessible again.