### PR TITLE
Surfaces redirects from URI-Ms. Closes #451

### DIFF
--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -655,7 +655,7 @@ def show_uri(path, datetime=None):
     if 'status_code' in jObj:
         status = jObj['status_code']
 
-    resp = Response(payload, status=jObj['status_code'])
+    resp = Response(payload, status=status)
 
     for idx, hLine in enumerate(hLines):
         k, v = hLine.split(': ', 1)


### PR DESCRIPTION
As documented, the regex to pull the part of the URI-M before the URI-R assumes a 14-digit string. This can be done more reliably but for now it fixes the issue of 3XXs not being replayed.