### PR TITLE
Show ipwb replay CLI help when no parameters passed and not piping

### DIFF
--- a/ipwb/__main__.py
+++ b/ipwb/__main__.py
@@ -65,6 +65,7 @@ def checkArgs_replay(args):
         print('> ipwb replay /path/to/your/index.cdxj\n')
 
         args.onError()
+        sys.exit()
 
 
 def checkArgs(argsIn):

--- a/ipwb/__main__.py
+++ b/ipwb/__main__.py
@@ -61,9 +61,10 @@ def checkArgs_replay(args):
     if suppliedIndexParameter:
         replay.start(cdxjFilePath=args.index, proxy=proxy)
     else:
-        # TODO: call replayParser.print_help()
-        print('Please supply a CDXJ file as an argument.')
-        sys.exit()
+        print('ERROR: An index file must be specified if not piping, e.g.,')
+        print('> ipwb replay /path/to/your/index.cdxj\n')
+
+        args.onError()
 
 
 def checkArgs(argsIn):
@@ -129,7 +130,8 @@ def checkArgs(argsIn):
         help='Proxy URL',
         metavar='<host:port>',
         nargs='?')
-    replayParser.set_defaults(func=checkArgs_replay)
+    replayParser.set_defaults(func=checkArgs_replay,
+                              onError=replayParser.print_help)
 
     parser.add_argument(
         '-d', '--daemon',


### PR DESCRIPTION
@ibnesayeed I realized I could pass the replayParser's help function in kwargs then execute it in the place we previously simply printed an error then returned. Please have a look at the code.

 Fixes #478