### PR TITLE
Correct typo and improve phrases in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ ipfs config Addresses.API /ip4/127.0.0.1/tcp/5002
 
 ## Indexing
 
-In a separate terminal session (or the same if you started the daemon in the background), instruct ipwb to push a WARC into IPFS:
+In a separate terminal session (or the same if you started the daemon in the background), instruct ipwb to push contents of a WARC file into IPFS and create an index of records:
 
 ```
 $ ipwb index (path to warc or warc.gz)
@@ -70,7 +70,7 @@ $ ipwb index (path to warc or warc.gz)
 $ ipwb index ipwb/samples/warcs/salam-home.warc
 ```
 
-The ipwb indexer parititions the WARC into WARC Records and extracts the WARC Response headers, HTTP response headers, and the HTTP response bodies (payloads). Relevant information is extracted from the WARC Response headers, temporary byte strings are created for the HTTP response headers and payload, and these two bytes strings are pushed into IPFS. The resulting CDXJ data is written to `STDOUT` by default but can be redirected to a file, e.g.,
+The ipwb indexer partitions the WARC into WARC Records and extracts the WARC Response headers, HTTP response headers, and the HTTP response bodies (payloads). Relevant information is extracted from the WARC Response headers, temporary byte strings are created for the HTTP response headers and payload, and these two bytes strings are pushed into IPFS. The resulting CDXJ data is written to `STDOUT` by default but can be redirected to a file, e.g.,
 
 ```
 $ ipwb index (path to warc or warc.gz) >> myArchiveIndex.cdxj


### PR DESCRIPTION
The motivation behind this change is to test our automated deployment setup.