### PR TITLE
Fix an issue where a unicode error occurs when utf-8 decoding is not …

### DIFF
--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -729,7 +729,7 @@ def show_uri(path, datetime=None):
         ipwbjsinject = """<script src="/ipwbassets/webui.js"></script>
                       <script>injectIPWBJS()</script>"""
 
-        newPayload = newPayload.decode().replace(
+        newPayload = newPayload.decode('utf-8').replace(
             '</html>', ipwbjsinject + '</html>')
 
         resp.set_data(newPayload)


### PR DESCRIPTION
…explicitly specified in py2

Sample WARC that exhibits this issue attached.

[20180905160919668.warc.txt](https://github.com/oduwsdl/ipwb/files/2353733/20180905160919668.warc.txt)

