### PR TITLE
Always execute IPFS daemon except when help flag is supplied

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ ("$1" = "ipwb") && ("$1" != "$@") && ("$@" != *" -h"*) && ("$@" != *" --help"*) ]]
+if [[ ("$@" != "ipwb") && ("$@" != *" -h"*) && ("$@" != *" --help"*) ]]
 then
     # Run the IPFS daemon in background, initialize configs if necessary
     ipfs daemon --init &


### PR DESCRIPTION
This should minimize the friction when we execute bash to manually run indexer or replay.