### PR TITLE
Mitigate noise from py-ipfs-api due to its mis-handling of 0-length payloads per #485

### DIFF
--- a/ipwb/indexer.py
+++ b/ipwb/indexer.py
@@ -71,6 +71,9 @@ def pushToIPFS(hstr, payload):
             if isinstance(payload, str):
                 payload = s2b(payload)
 
+            if len(payload) == 0:  # py-ipfs-api issue #137
+                return
+
             httpHeaderIPFSHash = pushBytesToIPFS(hstr)
             payloadIPFSHash = pushBytesToIPFS(payload)
 
@@ -376,7 +379,13 @@ def pushBytesToIPFS(bytes):
     global IPFS_API
 
     # Returns unicode in py2.7, str in py3.7
-    res = IPFS_API.add_bytes(bytes)  # bytes)
+    try:
+      res = IPFS_API.add_bytes(bytes)  # bytes)
+    except TypeError as err:
+        logError('IPFS_API had an issue pushing the item to IPFS')
+        logError(sys.exc_info())
+        logError(len(bytes))
+        traceback.print_tb(sys.exc_info()[-1])
 
     # TODO: verify that the add was successful
 

--- a/ipwb/indexer.py
+++ b/ipwb/indexer.py
@@ -380,7 +380,7 @@ def pushBytesToIPFS(bytes):
 
     # Returns unicode in py2.7, str in py3.7
     try:
-      res = IPFS_API.add_bytes(bytes)  # bytes)
+        res = IPFS_API.add_bytes(bytes)  # bytes)
     except TypeError as err:
         logError('IPFS_API had an issue pushing the item to IPFS')
         logError(sys.exc_info())


### PR DESCRIPTION
The issue of using py-ipfs-api to `add_bytes()` of zero-length payloads is still an outstanding issue per https://github.com/ipfs/py-ipfs-api/issues/137. This causes a _lot_ of noise by the ipwb indexer when encountering these records, like when indexing `samples/warcs/IAH-20080430204825-00000-blackbook.warc.gz`.

This PR prevents these records from being _attempted_ to be pushed into IPFS using py-ipfs-api. When https://github.com/ipfs/py-ipfs-api/issues/137 is fixed, we can change the logic but for now, this will short-circuit the attempt from ipwb. 