### PR TITLE
Considers the XHTML MIME type when displaying 'HTML pages' in replay …

### DIFF
--- a/ipwb/assets/webui.js
+++ b/ipwb/assets/webui.js
@@ -39,7 +39,10 @@ function addURIListToDOM () {
       li.setAttribute('data-mime', memento['mime'])
       li.setAttribute('data-status', memento['status'])
 
-      const isHTML = memento['mime'].toLowerCase().startsWith('text/html')
+      const mementoMIME = memento['mime'].toLowerCase()
+      const isHTML = mementoMIME.startsWith('text/html') ||
+        mementoMIME.startsWith('application/xhtml+xml')
+
       const isARedirect = memento['status'][0] === '3'
       if (isHTML && !isARedirect) {
         li.setAttribute('data-display', 'default')


### PR DESCRIPTION
…interface. Closes #558 

Tested with 2mementos_htmlXhtml.warc in master sample WARCs.