### PR TITLE
Fix proxy propagation for TG in Link and CDXJ TimeMaps

### DIFF
--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -435,8 +435,10 @@ def getProxiedURIT(uriT):
 
 def generateLinkTimeMapFromCDXJLines(cdxjLines, original, tmself, tgURI):
     tmurl = getProxiedURIT(tmself)
+
     if app.proxy is not None:
         tmself = urlunsplit(tmurl)
+        tgURI = urlunsplit(getProxiedURIT(tgURI))
 
     # Extract and trim for host:port prepending
     tmurl[2] = ''  # Clear TM path

--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -480,6 +480,7 @@ def generateCDXJTimeMapFromCDXJLines(cdxjLines, original, tmself, tgURI):
     tmurl = getProxiedURIT(tmself)
     if app.proxy is not None:
         tmself = urlunsplit(tmurl)
+        tgURI = urlunsplit(getProxiedURIT(tgURI))
 
     # unsurted URI will never have a scheme, add one
     originalURI = 'http://{0}'.format(unsurt(original))


### PR DESCRIPTION
This ties in the TG proxifying into existing logic and closes #327 with minimal code changes.