### PR TITLE
Fix IPFS webui link

### DIFF
--- a/ipwb/assets/serviceWorker.js
+++ b/ipwb/assets/serviceWorker.js
@@ -30,7 +30,7 @@ const rc = new Reconstructive({
 // <   localResource: function(FetchEvent) => boolean
 // < }
 rc.exclusions.specialEndpint = function (event, config) {
-  return ['/ipwbassets/', '/ipfsdaemon/', '/ipwbconfig/'].some(
+  return ['/ipwbassets/', '/ipfsdaemon/'].some(
     ep => event.request.url.startsWith(self.location.origin + ep))
 }
 

--- a/ipwb/assets/webui.js
+++ b/ipwb/assets/webui.js
@@ -188,7 +188,7 @@ function getIPFSWebUIAddress () {
   }
   const fail = function () { console.log('fail') }
   const err = function () { console.log('err') }
-  makeAnAJAXRequest('/ipwbconfig/openEndedPlaceHolder', setIPFSWebUILink, fail, err)
+  makeAnAJAXRequest('/ipfsdaemon/getwebuilink', setIPFSWebUILink, fail, err)
 }
 
 function updateIPFSDaemonButtonUI () {

--- a/ipwb/assets/webui.js
+++ b/ipwb/assets/webui.js
@@ -188,7 +188,7 @@ function getIPFSWebUIAddress () {
   }
   const fail = function () { console.log('fail') }
   const err = function () { console.log('err') }
-  makeAnAJAXRequest('/ipfsdaemon/getwebuilink', setIPFSWebUILink, fail, err)
+  makeAnAJAXRequest('/ipfsdaemon/webuilink', setIPFSWebUILink, fail, err)
 }
 
 function updateIPFSDaemonButtonUI () {

--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -553,7 +553,7 @@ def all_exception_handler(error):
 # the future.
 @app.route('/ipwbconfig/<requestedSetting>')
 def getRequestedSetting(requestedSetting):
-    return Response(ipwbUtils.getIPFSAPIHostAndPort() + '/ipwbassets')
+    return Response(ipwbUtils.getIPFSAPIHostAndPort() + '/webui')
 
 
 @app.route('/ipwbadmin', strict_slashes=False)

--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -157,7 +157,7 @@ def commandDaemon(cmd):
                 subprocess.call(['taskkill', '/im', 'ipfs.exe', '/F'])
 
         return Response('IPFS daemon stopping...')
-    elif cmd == 'getwebuilink':
+    elif cmd == 'webuilink':
         return Response(ipwbUtils.getIPFSAPIHostAndPort() + '/webui')
     else:
         print('ERROR, bad command sent to daemon API!')

--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -157,6 +157,8 @@ def commandDaemon(cmd):
                 subprocess.call(['taskkill', '/im', 'ipfs.exe', '/F'])
 
         return Response('IPFS daemon stopping...')
+    elif cmd == 'getwebuilink':
+        return Response(ipwbUtils.getIPFSAPIHostAndPort() + '/webui')
     else:
         print('ERROR, bad command sent to daemon API!')
         print(cmd)
@@ -546,14 +548,6 @@ def all_exception_handler(error):
     traceback.print_tb(sys.exc_info()[-1])
 
     return 'Error', 500
-
-
-# This route needs better restructuring but is currently only used to get the
-# webUI location for the ipwb webUI, more setting might need to be fetched in
-# the future.
-@app.route('/ipwbconfig/<requestedSetting>')
-def getRequestedSetting(requestedSetting):
-    return Response(ipwbUtils.getIPFSAPIHostAndPort() + '/webui')
 
 
 @app.route('/ipwbadmin', strict_slashes=False)


### PR DESCRIPTION
@ibnesayeed Note that this will not be exposed if not mapped with `-p` when running the docker container. Assuming the ODUCS instance is not using the remapping of port 5001, this should not introduce any sort of security issue. It also allows users to directly access the IPFS webui once again.

Closes #567