### PR TITLE
Improvements in header parsing

### DIFF
--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -721,7 +721,8 @@ def show_uri(path, datetime=None):
     for idx, hLine in enumerate(hLines):
         k, v = hLine.split(':', 1)
 
-        if k.lower() == 'transfer-encoding' and 'chunked' in v.lower():
+        if k.lower() == 'transfer-encoding' and \
+           re.search(r'\bchunked\b', v, re.I):
             try:
                 unchunkedPayload = extractResponseFromChunkedData(payload)
             except Exception as e:

--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -715,7 +715,7 @@ def show_uri(path, datetime=None):
     resp = Response(payload, status=status)
 
     for idx, hLine in enumerate(hLines):
-        k, v = hLine.split(': ', 1)
+        k, v = hLine.split(':', 1)
 
         if k.lower() == 'transfer-encoding' and 'chunked' in v.lower():
             try:

--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -705,7 +705,11 @@ def show_uri(path, datetime=None):
         header = cipher.decrypt(base64.b64decode(header))
         payload = cipher.decrypt(base64.b64decode(payload))
 
-    hLines = header.decode().split('\n')
+    hLines = header.decode() \
+                   .replace('\r', '') \
+                   .replace('\n\t', '\t') \
+                   .replace('\n ', ' ') \
+                   .split('\n')
     hLines.pop(0)
 
     status = 200

--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -717,7 +717,7 @@ def show_uri(path, datetime=None):
     for idx, hLine in enumerate(hLines):
         k, v = hLine.split(': ', 1)
 
-        if k.lower() == 'transfer-encoding' and v.lower() == 'chunked':
+        if k.lower() == 'transfer-encoding' and 'chunked' in v.lower():
             try:
                 unchunkedPayload = extractResponseFromChunkedData(payload)
             except Exception as e:


### PR DESCRIPTION
Closes #593

* Handle multi-valued `transfer-encoding` for dechunking
* Consider space after header name separator as optional
* Handle now-defunct line-wrapping in headers (which might be present in historical resources)