### PR TITLE
Temporarily install ipfshttpclient from master branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 warcio>=1.5.3
-ipfshttpclient>=0.4.13
+git+git://github.com/ipfs-shipyard/py-ipfs-http-client@master#egg=ipfshttpclient
 Flask==1.1.1
 pycryptodome>=3.4.11
 requests>=2.19.1

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     ],
     install_requires=[
         'warcio>=1.5.3',
-        'ipfshttpclient @ git+https://github.com/ipfs-shipyard/py-ipfs-http-client@master',
+        'ipfshttpclient @ git+https://github.com/ipfs-shipyard/py-ipfs-http-client@master',  # noqa: E501
         'Flask==1.1.1',
         'pycryptodome>=3.4.11',
         'requests>=2.19.1',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     ],
     install_requires=[
         'warcio>=1.5.3',
-        'ipfshttpclient>=0.4.12',
+        'ipfshttpclient @ git+https://github.com/ipfs-shipyard/py-ipfs-http-client@master',
         'Flask==1.1.1',
         'pycryptodome>=3.4.11',
         'requests>=2.19.1',


### PR DESCRIPTION
A recent change in the IPFS API removed support for GET/HEAD methods on some endpoints. This prevents us from upgrading to go-ipfs-v0.5.0 as per #638. Corresponding change in the `ipfshttpclient` is added to the `master` branch, but not released on PyPI yet. This is a temporary fix, but once the updated package is out, we should update the dependency.

Since this is a temporary fix, I am not changing the dependency in the `setup.py` file. Should I?