### PR TITLE
Drop Py 3.6 support and add 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ setup(
 
         'Environment :: Web Environment',
 
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
 
         'License :: OSI Approved :: MIT License',
 


### PR DESCRIPTION
Hopefully, it will change the metadata on PyPI and close #652.