### PR TITLE
Update ipfshttpclient dependency to ipfshttpclient4ipwb

### DIFF
--- a/ipwb/backends.py
+++ b/ipwb/backends.py
@@ -2,7 +2,7 @@ import dataclasses
 from typing import Optional
 from urllib.parse import urlparse
 
-import ipfshttpclient
+import ipfshttpclient4ipwb
 import requests
 
 from ipwb import util
@@ -35,10 +35,10 @@ def fetch_ipfs_index(path: str) -> Optional[str]:
         return None
 
     try:
-        with ipfshttpclient.connect(util.IPFSAPI_MUTLIADDRESS) as client:
+        with ipfshttpclient4ipwb.connect(util.IPFSAPI_MUTLIADDRESS) as client:
             return client.cat(path).decode('utf-8')
 
-    except ipfshttpclient.exceptions.StatusError as err:
+    except ipfshttpclient4ipwb.exceptions.StatusError as err:
         raise BackendError(backend_name='ipfs') from err
 
 

--- a/ipwb/indexer.py
+++ b/ipwb/indexer.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 import sys
 import os
 import json
-import ipfshttpclient as ipfsapi
+import ipfshttpclient4ipwb as ipfsapi
 import argparse
 import zlib
 import surt
@@ -27,7 +27,7 @@ from warcio.archiveiterator import ArchiveIterator
 from warcio.recordloader import ArchiveLoadFailed
 
 from requests.packages.urllib3.exceptions import NewConnectionError
-from ipfshttpclient.exceptions import ConnectionError
+from ipfshttpclient4ipwb.exceptions import ConnectionError
 # from requests.exceptions import ConnectionError
 
 from six.moves import input

--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -12,7 +12,7 @@ navigating their captures.
 from __future__ import print_function
 import sys
 import os
-import ipfshttpclient as ipfsapi
+import ipfshttpclient4ipwb as ipfsapi
 import json
 import subprocess
 import pkg_resources

--- a/ipwb/util.py
+++ b/ipwb/util.py
@@ -6,7 +6,7 @@ from os.path import basename
 import os
 import sys
 import requests
-import ipfshttpclient as ipfsapi
+import ipfshttpclient4ipwb as ipfsapi
 
 import re
 # Datetime conversion to rfc1123
@@ -22,8 +22,8 @@ from .__init__ import __version__ as ipwbVersion
 from pkg_resources import parse_version
 
 # from requests.exceptions import ConnectionError
-from ipfshttpclient.exceptions import ConnectionError
-from ipfshttpclient.exceptions import AddressError
+from ipfshttpclient4ipwb.exceptions import ConnectionError
+from ipfshttpclient4ipwb.exceptions import AddressError
 from multiaddr.exceptions import StringParseError
 
 IPFSAPI_MUTLIADDRESS = '/dns/localhost/tcp/5001/http'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 warcio>=1.5.3
-git+git://github.com/ipfs-shipyard/py-ipfs-http-client@master#egg=ipfshttpclient
+ipfshttpclient4ipwb
 Flask==1.1.1
 pycryptodome>=3.4.11
 requests>=2.19.1

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     ],
     install_requires=[
         'warcio>=1.5.3',
-        'ipfshttpclient @ git+https://github.com/ipfs-shipyard/py-ipfs-http-client@master',  # noqa: E501
+        'ipfshttpclient4ipwb',
         'Flask==1.1.1',
         'pycryptodome>=3.4.11',
         'requests>=2.19.1',

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 import pytest
-from ipfshttpclient.exceptions import StatusError
+from ipfshttpclient4ipwb.exceptions import StatusError
 
 from ipwb.backends import get_web_archive_index, BackendError
 from pathlib import Path
@@ -32,7 +32,7 @@ def test_ipfs_success():
     connect_to_ipfs = mock.MagicMock()
     connect_to_ipfs.return_value.cat.return_value = expected_content
 
-    with mock.patch('ipfshttpclient.connect', connect_to_ipfs):
+    with mock.patch('ipfshttpclient4ipwb.connect', connect_to_ipfs):
         assert get_web_archive_index(
             'QmReQCtRpmEhdWZVLhoE3e8bqreD8G3avGpVfcLD7r4K6W'
         ).startswith('!context ["http://tools.ietf.org/html/rfc7089"]')
@@ -41,7 +41,7 @@ def test_ipfs_success():
 def test_ipfs_failure():
     with pytest.raises(BackendError) as err_info:
         with mock.patch(
-            'ipfshttpclient.client.Client.cat',
+            'ipfshttpclient4ipwb.client.Client.cat',
             side_effect=StatusError(original='')
         ):
             get_web_archive_index(
@@ -60,7 +60,7 @@ def test_ipfs_url_success():
     connect_to_ipfs = mock.MagicMock()
     connect_to_ipfs.return_value.cat.return_value = expected_content
 
-    with mock.patch('ipfshttpclient.connect', connect_to_ipfs):
+    with mock.patch('ipfshttpclient4ipwb.connect', connect_to_ipfs):
         assert get_web_archive_index(
             'ipfs://QmReQCtRpmEhdWZVLhoE3e8bqreD8G3avGpVfcLD7r4K6W'
         ).startswith('!context ["http://tools.ietf.org/html/rfc7089"]')


### PR DESCRIPTION
This is due to ipfshttpclient not pushing a new release to pypi and ipwb needing to be compatible with newer go-ipfs binaries, which the currently released (to pypi) version of ipfshttpclient is not.