### PR TITLE
Add test to show breakage using variable len WARC-Dates for #283

### DIFF
--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -32,9 +32,9 @@ def test_warc_ipwbIndexerBrokenWARCRecord():
 # exhibiting these dates.
 @pytest.mark.ipwbIndexerVariableSizedDates
 def test_warc_ipwbIndexerVariableSizedDates():
-    pathOfBrokenWARC = os.path.join(
-        os.path.dirname(__file__) +
-        '/../samples/warcs/variableSizedDates.warc')
+    pathOfBrokenWARC = \
+        os.path.normpath(os.path.join(os.path.dirname(__file__), '..',
+                         'samples', 'warcs', 'variableSizedDates.warc'))
     indexer.indexFileAt(pathOfBrokenWARC, quiet=True)
 
 # TODO: Have unit tests for each function in indexer.py

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -27,4 +27,14 @@ def test_warc_ipwbIndexerBrokenWARCRecord():
     assert ipwbTest.countCDXJEntries(cdxj) == 1
 
 
+# WARC/1.1 allows for dates of length that are not easily converted
+# to 14-digits. This test highlights the failures from a WARC
+# exhibiting these dates.
+@pytest.mark.ipwbIndexerVariableSizedDates
+def test_warc_ipwbIndexerVariableSizedDates():
+    pathOfBrokenWARC = os.path.join(
+        os.path.dirname(__file__) +
+        '/../samples/warcs/variableSizedDates.warc')
+    indexer.indexFileAt(pathOfBrokenWARC, quiet=True)
+
 # TODO: Have unit tests for each function in indexer.py


### PR DESCRIPTION
Merges new test re:#283 to show that the indexer does not throw an exception when trying to parse WARC/1.1 dates beyond the WARC/1.0 spec. This could be more sophisticated but is a start to integrating the variableSizedDate WARC into the ipwb test suite.