### PR TITLE
Remove message about SW and Custom Elements from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ An important aspect of archival replay systems is rewriting various resource ref
 
 Another important feature of archival replays is the inclusion of an archival banner in mementos. The purpose of an archival banner is to highlight that a replayed page is a memento and not a live page, to provide metadata about the memento and the archive, and to facilitate additional interactivity. Many archival banners used in different web archival replay systems are obtrusive in nature and have issues like style leakage. To eliminate both of these issues we have implemented a [Custom HTML Element](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements), [<reconstructive-banner>](https://oduwsdl.github.io/Reconstructive/docs/class/Reconstructive/reconstructive-banner.js~ReconstructiveBanner.html) as part of the [Reconstructive](https://oduwsdl.github.io/Reconstructive/) library and used in the ipwb.
 
-Both *Service Worker* and *Custom Element* APIs are new and only supported in modern web browsers (e.g., Chrome > v67, Firefox > v63).
-
 ## Installing
 
 InterPlanetary Wayback (ipwb) requires Python 3.7+. ipwb can also be used with Docker ([see below](#user-content-using-docker)).


### PR DESCRIPTION
After testing ipwb on desktop Safari, despite its lack of full
support for Custom Elements, ipwb replay is still usable in
the browser. The message in the README now is unnecessary
warning that a modern browser is needed. This fix merely
removes the message from the README.

Closes #632