### PR TITLE
Require explicit version of py-ipfs-http-client fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 warcio>=1.5.3
-ipfshttpclient4ipwb
+ipfshttpclient4ipwb>=0.6.0
 Flask==1.1.1
 pycryptodome>=3.4.11
 requests>=2.19.1

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     ],
     install_requires=[
         'warcio>=1.5.3',
-        'ipfshttpclient4ipwb',
+        'ipfshttpclient4ipwb>=0.6.0',
         'Flask==1.1.1',
         'pycryptodome>=3.4.11',
         'requests>=2.19.1',


### PR DESCRIPTION
Require explicit version of py-ipfs-http-client fork so versions
of ipwb, the module, and go-ipfs align.

@ibnesayeed Given version mis-alignment because of some of the tests in the imported module caused breakage, I wanted to be more explicit with the version of the forked module.