### PR TITLE
Rm dead code, re:#63

### DIFF
--- a/ipwb/util.py
+++ b/ipwb/util.py
@@ -121,12 +121,6 @@ def isLocalHosty(uri):
     return False
 
 
-def setupIPWBInIPFSConfig():
-    hostPort = getIPWBReplayConfig()
-    if not hostPort:
-        setIPWBReplayConfig(IPWBREPLAY_HOST, IPWBREPLAY_PORT)
-
-
 def setLocale():
     currentOS = platform.system()
 


### PR DESCRIPTION
In investigating how coupled we are with reading and writing the ipwb config to the IPFS config file, I found that this function is never called.

@ibnesayeed If I recall, you wanted this interaction with the config file to be removed, correct? If so, #63 might be moot and instead, there should be an issue to remove it (i.e., #349).