### PR TITLE
Remove futures

### DIFF
--- a/ipwb/indexer.py
+++ b/ipwb/indexer.py
@@ -10,7 +10,6 @@ This script reads a WARC file and returns a CDXJ representative of its
  JSON block corresponding to the archived URI.
 """
 
-from __future__ import print_function
 import sys
 import os
 import json

--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -9,7 +9,6 @@ indexer. An interface is supplied when first started to assist the user in
 navigating their captures.
 """
 
-from __future__ import print_function
 import sys
 import os
 import ipfshttpclient4ipwb as ipfsapi

--- a/ipwb/util.py
+++ b/ipwb/util.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from os.path import expanduser
 from os.path import basename
 
@@ -119,12 +117,6 @@ def isLocalHosty(uri):
         if lh in uri:
             return True
     return False
-
-
-def setupIPWBInIPFSConfig():
-    hostPort = getIPWBReplayConfig()
-    if not hostPort:
-        setIPWBReplayConfig(IPWBREPLAY_HOST, IPWBREPLAY_PORT)
 
 
 def setLocale():

--- a/ipwb/util.py
+++ b/ipwb/util.py
@@ -119,6 +119,12 @@ def isLocalHosty(uri):
     return False
 
 
+def setupIPWBInIPFSConfig():
+    hostPort = getIPWBReplayConfig()
+    if not hostPort:
+        setIPWBReplayConfig(IPWBREPLAY_HOST, IPWBREPLAY_PORT)
+
+
 def setLocale():
     currentOS = platform.system()
 


### PR DESCRIPTION
Remove futures import, given Py2 is no longer supported and the import is unnecessary.