### PR TITLE
WIP: GH Actions for Windows test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          # - windows-latest
+          - windows-latest
         python:
           - 3.7
           - 3.8


### PR DESCRIPTION
Check to see with the updated path conversion where we rely on the delimiter of the OS was an issue on Windows.