### PR TITLE
Remove unnecessary condition from Docker image build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   build-image:
-    if: secrets.DOCKER_REPO
     runs-on: ubuntu-latest
     name: Docker Image
     steps:


### PR DESCRIPTION
This should fix the Docker image build issue. Also, release notes should now not gobble white spaces in file listing (due to a fix in https://github.com/ibnesayeed/repo-attrs/commit/e7bdd1fc08eb1588e3ae04c21614d9c2a07e7e1e).