### PR TITLE
Fix a typo in the build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Docker Build
 
 on:
   push:
-    branchs:
+    branches:
       - master
     tags:
       - '*'


### PR DESCRIPTION
The term `branches` was misspelled.