### PR TITLE
Moves online version check to separate function.

### DIFF
--- a/ipwb/__main__.py
+++ b/ipwb/__main__.py
@@ -147,8 +147,7 @@ def checkArgs(argsIn):
     parser.add_argument(
         '-u', '--update-check',
         action='store_true',
-        help=('Checks remotely to determine if the installed version '
-              'of ipwb is current')
+        help='Check whether an updated version of ipwb is available'
         )
     parser.set_defaults(func=ipwbUtil.checkForUpdate)
 

--- a/ipwb/__main__.py
+++ b/ipwb/__main__.py
@@ -15,8 +15,7 @@ from .util import IPWBREPLAY_HOST, IPWBREPLAY_PORT
 
 
 def main():
-    ipwbUtil.checkForUpdate()
-    args = checkArgs(sys.argv)
+    checkArgs(sys.argv)
 
 
 def checkArgs_index(args):
@@ -145,10 +144,18 @@ def checkArgs(argsIn):
     parser.add_argument(
         '-v', '--version', help='Report the version of ipwb', action='version',
         version='InterPlanetary Wayback ' + ipwbVersion)
+    parser.add_argument(
+        '-u', '--update-check',
+        action='store_true',
+        help=('Checks remotely to determine if the installed version '
+              'of ipwb is current')
+        )
+    parser.set_defaults(func=ipwbUtil.checkForUpdate)
 
     argCount = len(argsIn)
     cmdList = ['index', 'replay']
-    baseParserFlagList = ['-d', '--daemon', '-v', '--version']
+    baseParserFlagList = ['-d', '--daemon', '-v', '--version',
+                          '-u', '--update-check']
 
     # Various invocation error, used to show appropriate help
     cmdError_index = argCount == 2 and argsIn[1] == 'index'

--- a/ipwb/util.py
+++ b/ipwb/util.py
@@ -308,11 +308,11 @@ def compareCurrentAndLatestIPWBVersions():
         return (None, None)
 
 
-def checkForUpdate():
+def checkForUpdate(_):
     (current, latest) = compareCurrentAndLatestIPWBVersions()
 
     if current != latest and current is not None:
         print('This version of ipwb is outdated.'
               ' Please run pip install --upgrade ipwb.')
-        print(f'* Latest version: {latest}')
-        print(f'* Installed version: {current}')
+    print(f'* Latest version: {latest}')
+    print(f'* Installed version: {current}')


### PR DESCRIPTION
By default, the ipwb version check makes a request to pypi.org to determine if the
currently installed version is current. This should not occur -- the command should
be executed locally and the current version reported. However, this functionality is
useful, so I have put it behind a separate flag.

Closes #676