### PR TITLE
Fix image src to be relative in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![image](https://raw.githubusercontent.com/oduwsdl/ipwb/master/docs/logo.png)](https://pypi.python.org/pypi/ipwb)
+[![image](docs/logo.png)](https://pypi.python.org/pypi/ipwb)
 
 # InterPlanetary Wayback (ipwb)
 


### PR DESCRIPTION
The image in the README is absolute. This causes an issue when we are editing it, as the reference always points to the current master and not the relative one in the branch. This PR fixes the reference to be relative.