### PR TITLE
Fix logic and message reported for version if inaccessible.

### DIFF
--- a/ipwb/__main__.py
+++ b/ipwb/__main__.py
@@ -149,7 +149,7 @@ def checkArgs(argsIn):
         action='store_true',
         help='Check whether an updated version of ipwb is available'
         )
-    parser.set_defaults(func=util.checkForUpdate)
+    parser.set_defaults(func=util.check_for_update)
 
     argCount = len(argsIn)
     cmdList = ['index', 'replay']

--- a/ipwb/util.py
+++ b/ipwb/util.py
@@ -9,7 +9,6 @@ import requests
 import re
 # Datetime conversion to rfc1123
 import locale
-import dataclasses
 import datetime
 import logging
 import platform
@@ -317,40 +316,23 @@ def unsurt(surt):
         return surt
 
 
-@dataclasses.dataclass(frozen=True)
-class VersionCompareError(Exception):
-    installed_version: str
-
-    def __str__(self):
-        return ('pypi.org unavailable, '
-                'unable to check if installed version is latest.\n'
-                f'* Installed version {self.installed_version}.'
-                )
-
-
-def compare_installed_and_latest_ipwb_versions():
-    installed_version = None
+def get_latest_version():
     try:
-        installed_version = re.sub(r'\.0+', '.', ipwb_version)
         resp = urlopen('https://pypi.org/pypi/ipwb/json')
-        jResp = json.loads(resp.read())
-        latest_version = jResp['info']['version']
-        return (installed_version, latest_version)
-    except URLError:  # pypi.org unavailable
-        raise VersionCompareError(installed_version=installed_version)
+        return json.loads(resp.read())['info']['version']
+    except:
+        return None
 
 
-def checkForUpdate(_):
-    try:
-        (installed, latest) = compare_installed_and_latest_ipwb_versions()
-
-        if installed != latest and installed is not None:
-            print('This version of ipwb is outdated.'
-                  ' Please run pip install --upgrade ipwb.')
-        print(f'* Latest version: {latest}')
-        print(f'* Installed version: {installed}')
-    except VersionCompareError as err:
-        print(err)
-    except Exception as err:
-        print("An unknown error occurred.")
-        print(err)
+def check_for_update(_):
+    latest = get_latest_version()
+    if not latest:
+        print("Failed to check for the latest version.")
+        return
+    current = re.sub(r'\.0+', '.', ipwb_version)
+    if latest == current:
+        print(f"Installed version {current} is up to date.")
+    else:
+        print("The installed version of ipwb is outdated.")
+        print(f"Installed: {current}\nLatest:    {latest}")
+        print("Please run `pip install --upgrade ipwb` to upgrade.")

--- a/ipwb/util.py
+++ b/ipwb/util.py
@@ -334,5 +334,5 @@ def check_for_update(_):
         print(f"Installed version {current} is up to date.")
     else:
         print("The installed version of ipwb is outdated.")
-        print(f"Installed: {current}\nLatest:    {latest}")
+        print(f"* Installed: {current}\n* Latest:    {latest}")
         print("Please run `pip install --upgrade ipwb` to upgrade.")

--- a/ipwb/util.py
+++ b/ipwb/util.py
@@ -320,7 +320,7 @@ def get_latest_version():
     try:
         resp = urlopen('https://pypi.org/pypi/ipwb/json')
         return json.loads(resp.read())['info']['version']
-    except:
+    except Exception:
         return None
 
 

--- a/ipwb/util.py
+++ b/ipwb/util.py
@@ -332,7 +332,7 @@ def compare_installed_and_latest_ipwb_versions():
     installed_version = None
     try:
         installed_version = re.sub(r'\.0+', '.', ipwb_version)
-        resp = urlopen('https://pypi.python.org/pypi/ipwb/json')
+        resp = urlopen('https://pypi.org/pypi/ipwb/json')
         jResp = json.loads(resp.read())
         latest_version = jResp['info']['version']
         return (installed_version, latest_version)


### PR DESCRIPTION
This PR includes some handling of instances where pypi.org
is offline or inaccessible. I also cleaned up some of the
naming and introduced an exception dataclass to make handling
this issue more clear. Also also, I removed the dependence
on the six module to instead use the provided urllib
urlopen method.

Closes #700