### PR TITLE
Update to use latest (albeit alpha) ipfshttpclient, support go-ipfs 0.7.0 and 0.8.0 in testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,13 @@ jobs:
         python:
           - 3.7
           - 3.8
+          - 3.9
         ipfs:
           - 0.4
           - 0.5
           - 0.6
+          - 0.7
+          - 0.8
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} Py-${{ matrix.python }} IPFS-${{ matrix.ipfs }}
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.7"
   - "3.8"
 before_script:
-  - wget "https://dist.ipfs.io/go-ipfs/v0.6.0/go-ipfs_v0.6.0_linux-amd64.tar.gz" -O /tmp/ipfs.tar.gz
+  - wget "https://dist.ipfs.io/go-ipfs/v0.8.0/go-ipfs_v0.8.0_linux-amd64.tar.gz" -O /tmp/ipfs.tar.gz
   #- mkdir $HOME/bin
   - pushd . && cd $HOME/bin && tar -xzvf /tmp/ipfs.tar.gz && popd
   - export PATH="$HOME/bin/go-ipfs:$PATH"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 warcio>=1.5.3
-ipfshttpclient>=0.6.1
+ipfshttpclient>=0.8.0a
 Flask==1.1.1
 pycryptodome>=3.4.11
 requests>=2.19.1


### PR DESCRIPTION
The prerelease of the dependency (on PyPI) fixes the version check issues that caused tests to fail.

Closes #716 and #726