### PR TITLE
Update http (not s) refs to IETF URI to use https

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
     name: ${{ matrix.os }} Py-${{ matrix.python }} IPFS-${{ matrix.ipfs }}
     steps:
       - uses: actions/checkout@v2
-      - name: Echo branch being used
-        run: git branch
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
     name: ${{ matrix.os }} Py-${{ matrix.python }} IPFS-${{ matrix.ipfs }}
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Echo branch being used
         run: git branch
       - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
     name: ${{ matrix.os }} Py-${{ matrix.python }} IPFS-${{ matrix.ipfs }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Echo branch being used
+        run: git branch
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2
         with:

--- a/ipwb/indexer.py
+++ b/ipwb/indexer.py
@@ -300,7 +300,7 @@ def cdx_cdxj_lines_from_file(warc_path, **enc_comp_opts):
 
 
 def generate_cdxj_metadata(cdxj_lines=None):
-    metadata = ['!context ["http://tools.ietf.org/html/rfc7089"]']
+    metadata = ['!context ["https://tools.ietf.org/html/rfc7089"]']
     meta_vals = {
         'generator': f'InterPlanetary Wayback {ipwb_version}',
         'created_at': datetime.datetime.now().isoformat()

--- a/ipwb/replay.py
+++ b/ipwb/replay.py
@@ -507,7 +507,7 @@ def generate_cdxj_timemap_from_cdxj_lines(
     # unsurted URI will never have a scheme, add one
     original_uri = f'http://{unsurt(original)}'
 
-    tm_data = '!context ["http://tools.ietf.org/html/rfc7089"]\n'
+    tm_data = '!context ["https://tools.ietf.org/html/rfc7089"]\n'
     tm_data += f'!id {{"uri": "{tm_self}"}}\n'
     tm_data += '!keys ["memento_datetime_YYYYMMDDhhmmss"]\n'
     tm_data += f'!meta {{"original_uri": "{original_uri}"}}\n'

--- a/samples/indexes/froggie_badHeaderHash.cdxj
+++ b/samples/indexes/froggie_badHeaderHash.cdxj
@@ -1,4 +1,4 @@
-!context ["http://tools.ietf.org/html/rfc7089"]
+!context ["https://tools.ietf.org/html/rfc7089"]
 !meta {"created_at": "2018-01-30T16:52:43.212606", "generator": "InterPlanetary Wayback 0.2018.01.10.0435"}
 com,matkelly)/froggies/frog.png 20170301192639 {"locator": "urn:ipfs/QmUeko8zM7Xanwz6F9GtRH4rLAi4Poj3DMECGsci2BRQfs/QmPhMnX74cwqx2xgj9d3N3gTra8CzafXwSbUwU8xagMfqR", "original_uri": "http://matkelly.com/froggies/frog.png", "mime_type": "image/png", "status_code": "200"}
 com,matkelly)/robots.txt 20170301192639 {"locator": "urn:ipfs/Qmbk3Aju7u26Pzk356a43wY9eUCScAJiLPxhvwsMoVt7Pd/QmYNB85U2txRAAdLp6wvZSPvd8AQq8UcjZJ2azhv5h6NF7", "original_uri": "http://matkelly.com/robots.txt", "mime_type": "text/plain", "status_code": "200"}

--- a/samples/indexes/salam-home.cdxj
+++ b/samples/indexes/salam-home.cdxj
@@ -1,3 +1,3 @@
-!context ["http://tools.ietf.org/html/rfc7089"]
+!context ["https://tools.ietf.org/html/rfc7089"]
 !meta {"created_at": "2018-07-28T14:07:36.044446", "generator": "InterPlanetary Wayback 0.2018.07.27.2357"}
 edu,odu,cs)/~salam/ 20160305192247 {"locator": "urn:ipfs/QmNkt4JbkTemhUDmua7JW5NaTQWCrVZbk2EvUvhhPm9NJP/QmQr2uoXCbmC5c1vLngeE9HU1CHfF7BVG2z98JR6DQNFoU", "original_uri": "http://www.cs.odu.edu/~salam/", "mime_type": "text/html", "status_code": "200"}

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -14,7 +14,7 @@ SAMPLE_INDEX = str(
 
 def test_local():
     assert get_web_archive_index(SAMPLE_INDEX).startswith(
-        '!context ["http://tools.ietf.org/html/rfc7089"]'
+        '!context ["https://tools.ietf.org/html/rfc7089"]'
     )
 
 
@@ -22,7 +22,7 @@ def test_https():
     assert get_web_archive_index(
         'https://raw.githubusercontent.com/oduwsdl/ipwb/master/samples/' +
         'indexes/salam-home.cdxj'
-    ).startswith('!context ["http://tools.ietf.org/html/rfc7089"]')
+    ).startswith('!context ["https://tools.ietf.org/html/rfc7089"]')
 
 
 def test_ipfs_success():
@@ -35,7 +35,7 @@ def test_ipfs_success():
     with mock.patch('ipfshttpclient.connect', connect_to_ipfs):
         assert get_web_archive_index(
             'QmReQCtRpmEhdWZVLhoE3e8bqreD8G3avGpVfcLD7r4K6W'
-        ).startswith('!context ["http://tools.ietf.org/html/rfc7089"]')
+        ).startswith('!context ["https://tools.ietf.org/html/rfc7089"]')
 
 
 def test_ipfs_failure():
@@ -63,4 +63,4 @@ def test_ipfs_url_success():
     with mock.patch('ipfshttpclient.connect', connect_to_ipfs):
         assert get_web_archive_index(
             'ipfs://QmReQCtRpmEhdWZVLhoE3e8bqreD8G3avGpVfcLD7r4K6W'
-        ).startswith('!context ["http://tools.ietf.org/html/rfc7089"]')
+        ).startswith('!context ["https://tools.ietf.org/html/rfc7089"]')


### PR DESCRIPTION
There are a few references throughout the codebase/tests to `http://tools.ietf.org/html/rfc7089`, which results in a 404 when dereferenced. This PR uses the same URI but with `https` as the scheme, which resolves.

Perhaps trivial but also critical to provide the `context` where it is used.