### PR TITLE
Patch in a modification of the CDXJ for the expected tests to pull

### DIFF
--- a/samples/indexes/salam-home.cdxj
+++ b/samples/indexes/salam-home.cdxj
@@ -1,3 +1,3 @@
-!context ["http://tools.ietf.org/html/rfc7089"]
+!context ["https://tools.ietf.org/html/rfc7089"]
 !meta {"created_at": "2018-07-28T14:07:36.044446", "generator": "InterPlanetary Wayback 0.2018.07.27.2357"}
 edu,odu,cs)/~salam/ 20160305192247 {"locator": "urn:ipfs/QmNkt4JbkTemhUDmua7JW5NaTQWCrVZbk2EvUvhhPm9NJP/QmQr2uoXCbmC5c1vLngeE9HU1CHfF7BVG2z98JR6DQNFoU", "original_uri": "http://www.cs.odu.edu/~salam/", "mime_type": "text/html", "status_code": "200"}


### PR DESCRIPTION
in remotely in #739.

Because the test expects the value to already be present in master,
it is invalid. This should help #739 pass.