### PR TITLE
Add tests for TimeMap retrieval via replay endpoint

### DIFF
--- a/samples/indexes/5mementos.cdxj
+++ b/samples/indexes/5mementos.cdxj
@@ -1,0 +1,11 @@
+!context ["https://tools.ietf.org/html/rfc7089"]
+!id {"uri": "http://localhost:5000/timemap/cdxj/memento.us"}
+!keys ["memento_datetime_YYYYMMDDhhmmss"]
+!meta {"original_uri": "http://memento.us/"}
+!meta {"timegate_uri": "http://localhost:5000/timegate/memento.us"}
+!meta {"timemap_uri": {"link_format": "http://localhost:5000/timemap/link/memento.us","cdxj_format": "http://localhost:5000/timemap/cdxj/memento.us"}}
+20130202100000 {"uri": "http://localhost:5000/memento/20130202100000/memento.us/", "rel": "first memento", "datetime"="Sat, 02 Feb 2013 10:00:00 GMT"}
+20140114100000 {"uri": "http://localhost:5000/memento/20140114100000/memento.us/", "rel": "memento", "datetime"="Tue, 14 Jan 2014 10:00:00 GMT"}
+20140115101500 {"uri": "http://localhost:5000/memento/20140115101500/memento.us/", "rel": "memento", "datetime"="Wed, 15 Jan 2014 10:15:00 GMT"}
+20161231110000 {"uri": "http://localhost:5000/memento/20161231110000/memento.us/", "rel": "memento", "datetime"="Sat, 31 Dec 2016 11:00:00 GMT"}
+20161231110001 {"uri": "http://localhost:5000/memento/20161231110001/memento.us/", "rel": "last memento", "datetime"="Sat, 31 Dec 2016 11:00:01 GMT"}

--- a/samples/indexes/5mementos.link
+++ b/samples/indexes/5mementos.link
@@ -1,0 +1,9 @@
+<http://memento.us/>; rel="original",
+<http://localhost:5000/timemap/link/memento.us>; rel="self timemap"; type="application/link-format",
+<http://localhost:5000/timemap/cdxj/memento.us>; rel="timemap"; type="application/cdxj+ors",
+<http://localhost:5000/timegate/memento.us>; rel="timegate",
+<http://localhost:5000/memento/20130202100000/memento.us/>; rel="first memento"; datetime="Sat, 02 Feb 2013 10:00:00 GMT",
+<http://localhost:5000/memento/20140114100000/memento.us/>; rel="memento"; datetime="Tue, 14 Jan 2014 10:00:00 GMT",
+<http://localhost:5000/memento/20140115101500/memento.us/>; rel="memento"; datetime="Wed, 15 Jan 2014 10:15:00 GMT",
+<http://localhost:5000/memento/20161231110000/memento.us/>; rel="memento"; datetime="Sat, 31 Dec 2016 11:00:00 GMT",
+<http://localhost:5000/memento/20161231110001/memento.us/>; rel="last memento"; datetime="Sat, 31 Dec 2016 11:00:01 GMT"

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -2,6 +2,7 @@ import pytest
 
 from . import testUtil as ipwb_test
 from ipwb import replay
+
 from time import sleep
 
 import requests
@@ -107,6 +108,22 @@ def test_replay_dated_memento():
 
     resp = requests.get(url.format('20160305192247'), allow_redirects=False)
     assert resp.status_code == 200
+
+    ipwb_test.stop_replay()
+
+
+@pytest.mark.parametrize("warc,index,tmformat,urim", [
+    ('5mementos.warc', '5mementos.cdxj', 'cdxj', 'memento.us'),
+    ('5mementos.warc', '5mementos.link', 'link', 'memento.us')
+])
+def test_generate_timemap(warc, index, tmformat, urim):
+    ipwb_test.start_replay(warc)
+
+    resp = requests.get(f'http://localhost:5000/timemap/{tmformat}/{urim}',
+                        allow_redirects=False)
+
+    with open(f'samples/indexes/{index}', 'r') as index:
+        assert index.read().encode('utf-8') == resp.content
 
     ipwb_test.stop_replay()
 


### PR DESCRIPTION
Per @ibnesayeed at https://github.com/oduwsdl/ipwb/pull/742#issuecomment-904059560

While a better approach might be to have unit tests for the functions, I believe this addition is a step in the right direction.

Relates to #180, too.