### PR TITLE
Fix reference to function that changed names

### DIFF
--- a/ipwb/__main__.py
+++ b/ipwb/__main__.py
@@ -18,7 +18,7 @@ def main():
     check_args(sys.argv)
 
 
-def checkArgs_index(args):
+def check_args_index(args):
     # args.daemon_address is always set. Either default or by CLI
     try:
         # see if it parses

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -29,29 +29,29 @@ def test_daemon_wrong_scheme():
     daemon = "/dnswrong/localhost/tcp/5001/http"
     args['daemon_address'] = daemon
     with pytest.raises(multiaddr_exceptions.StringParseError):
-        __main__.checkArgs_index(dotdict(args))
-        __main__.checkArgs_replay(dotdict(args))
+        __main__.check_args_index(dotdict(args))
+        __main__.check_args_replay(dotdict(args))
 
 
 def test_daemon_wrong_ip():
     daemon = "/ip4/256.999.478.444/tcp/5001/http"
     args['daemon_address'] = daemon
     with pytest.raises(multiaddr_exceptions.StringParseError):
-        __main__.checkArgs_index(dotdict(args))
-        __main__.checkArgs_replay(dotdict(args))
+        __main__.check_args_index(dotdict(args))
+        __main__.check_args_replay(dotdict(args))
 
 
 def test_daemon_wrong_protocol():
     daemon = "/dns/localhost/tcp/5001/httpwrong"
     args['daemon_address'] = daemon
     with pytest.raises(multiaddr_exceptions.StringParseError):
-        __main__.checkArgs_index(dotdict(args))
-        __main__.checkArgs_replay(dotdict(args))
+        __main__.check_args_index(dotdict(args))
+        __main__.check_args_replay(dotdict(args))
 
 
 def test_daemon_wrong_format():
     daemon = "localhost:5001"
     args['daemon_address'] = daemon
     with pytest.raises(multiaddr_exceptions.StringParseError):
-        __main__.checkArgs_index(dotdict(args))
-        __main__.checkArgs_replay(dotdict(args))
+        __main__.check_args_index(dotdict(args))
+        __main__.check_args_replay(dotdict(args))


### PR DESCRIPTION
In c36fee6c2915fc545aa1ea2668e6bda5f75f36cd I (am to blame) tweaked the function name to conform with snake style without adjusting the function name. This commit aligns the caller and callee's names.

Closes #808