### PR TITLE
Update tests to use kubo v0.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
           - "3.10"
           - "3.11"
         ipfs:
-          - "0.22"
           - "0.23"
           - "0.24"
+          - "0.25"
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} Py-${{ matrix.python }} IPFS-${{ matrix.ipfs }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN        mkdir -p /data/{warc,cdxj,ipfs}
 
 # Download and install IPFS
 ENV        IPFS_PATH=/data/ipfs
-ARG        IPFS_VERSION=v0.24.0
+ARG        IPFS_VERSION=v0.25.0
 RUN        cd /tmp \
            && wget -q https://dist.ipfs.io/kubo/${IPFS_VERSION}/kubo_${IPFS_VERSION}_linux-amd64.tar.gz \
            && tar xvfz kubo*.tar.gz \


### PR DESCRIPTION
Closes #820

The tests should pass for the new version of kubo when the new version of kubo (beyond the RCs) is released and available.